### PR TITLE
std::unique_ptr deleter unit tests.

### DIFF
--- a/tests/pure_cpp/CMakeLists.txt
+++ b/tests/pure_cpp/CMakeLists.txt
@@ -9,6 +9,7 @@ else()
 endif()
 
 add_executable(smart_holder_poc_test smart_holder_poc_test.cpp)
+target_compile_options(smart_holder_poc_test PRIVATE "-g")
 pybind11_enable_warnings(smart_holder_poc_test)
 target_link_libraries(smart_holder_poc_test PRIVATE pybind11::headers Catch2::Catch2)
 

--- a/tests/pure_cpp/smart_holder_poc_test.cpp
+++ b/tests/pure_cpp/smart_holder_poc_test.cpp
@@ -356,7 +356,6 @@ TEST_CASE("from_unique_ptr_std_function_with_deleter+as_unique_ptr_with_std_func
     REQUIRE(destructor_called == false);
     new_owner.reset();
     REQUIRE(destructor_called);
-    
 }
 
 


### PR DESCRIPTION
## Description

Hello again @rwgk , I saw your call for unit test help in the https://github.com/pybind/pybind11/pull/2839#issuecomment-1774183834 issue (long time watcher on that issue ;) ), I had some time to spare so I took a stab at your unit test request.

So I wasn't too familiar with the original issue, but from the looks of it the main thing is that we need to be able to handle and test custom deleters that are a closure are called at the correct times, only when the delete actually happens.

I tried to think some unit tests around this and came up with these two:
- `from_unique_ptr_with_std_function_deleter+as_lvalue_ref+destructor_called`
  - Checks that `std::function` deleter is not invoked when moved from a unique pointer into the smart holder.
  - Verifies the deleter is invoked when the smart holder is destructed.
- `from_unique_ptr_with_std_function_deleter+as_raw_ptr_release_ownership`
  - Checks that anything with a `std::function` deleter cannot be disowned.

Then I saw the `unique_ptr -> holder -> unique_ptr` roundtrip unit test... and realised that the deleter should also survive that roundtrip, so I added;
- `from_unique_ptr_std_function_with_deleter+as_unique_ptr_with_std_function_deleter1`
  - Confirms that the `std::function` deleter survives the roundtrip.

Problem is, that third unit tests failed... because the `as_unique_ptr` [method](https://github.com/rwgk/pybind11/blob/d815d7d321f78136b3df8b3a1c888871c0ffb3e1/include/pybind11/detail/smart_holder_poc.h#L338-L345) on the smart holder didn't extract the deleter from the shared pointer to pass it on to the returned `unique_ptr`. In 1ce70539e9a5bd696e6b561f93ecebc8cb5348c9 and 84033fd66faeb724e7a130f3d8ee5a2a57aed705 I tried to remedy this issue, because I think we should pass along the deleter if we go from a smart holder back to a unique pointer.

Unfortunately, the unit tests with:
```cpp
    REQUIRE_THROWS_WITH((hld.as_unique_ptr<int, helpers::functor_other_delete<int>>()),
                        "Incompatible unique_ptr deleter (as_unique_ptr).");
```

Made this a bit problematic, as that made it impossible to just do an assign into the deleter type of the unique pointer, so there's a tiny trait system [here](https://github.com/iwanders/pybind11/blob/d9f571ca67bf00774625022a5864165fd4c61db6/include/pybind11/detail/smart_holder_poc.h#L71-L86) to ensure the assign only happens if the type is actually assignable (preventing compilation errors with the `hld.as_unique_ptr<int, helpers::functor_other_delete<int>>()` unit tests).

Upon writing this, I think we should actually throw if we have a deleter but are using a return type that cannot accomodate our custom deleter.

Either way, this PR is definitely not ready, I expect formatters & linters will complain about many things, but thought I'd file it anyway to open discussion.


